### PR TITLE
allow loading of external config file

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,16 @@ module.exports = class AutoreloadTrailpack extends Trailpack {
       return
     }
 
-    this.watcher = chokidar.watch([ 'api/**/*.js', 'config/**/*.js' ], {
+    let config = {
       cwd: this.app.config.main.paths.root,
-      ignoreInitial: true
-    })
+      ignoreInitial: true,
+    }
+
+    if (this.app.config.hasOwnProperty('autoreload')) {
+      config = this.app.config.autoreload;
+    }
+
+    this.watcher = chokidar.watch([ 'api/**/*.js', 'config/**/*.js' ], config);
 
     this.watcher
       .on('change', file => this.reloadApp(file))


### PR DESCRIPTION
The change allows users to load an external autoreload config.  If non is provided the default one is used.   Essentially, gives the user more control of this pack's underlining behavior without having to touch the npm-module directly. 

**How to use**
1.  Create new file within your trails app.  config/autoreload.js
2. Add content 

module.exports = {
cwd: '/srv/project',
ignoreInitial: true,
usePolling: true
}
1. Reload app. 
